### PR TITLE
Add face tracking and recognition spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test test-audio reachy-sim reachy-sim-setup push-cappenz \
+.PHONY: run test test-model test-audio reachy-sim reachy-sim-setup push-cappenz \
 	reachy-daemon-install reachy-daemon-uninstall reachy-daemon-start \
 	reachy-daemon-stop reachy-daemon-status reachy-daemon-logs reachy-daemon-print
 
@@ -8,7 +8,10 @@ run:
 	uv run --env-file .env python3 kitchen_agent.py
 
 test:
-	uv run pytest -m "not manual" tests
+	uv run pytest -m "not manual and not model" tests
+
+test-model:
+	uv run pytest -m model tests -s
 
 test-audio:
 	CHORES_TEST_AUDIO=1 uv run --env-file .env pytest -m manual tests/manual/test_audio.py -s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ pythonpath = ["."]
 testpaths = ["tests"]
 markers = [
     "manual: explicit manual tests that may use paid services, hardware, or external integrations",
+    "model: explicit model validation tests that may load ML model artifacts or require representative image data",
 ]

--- a/reachy/companion.py
+++ b/reachy/companion.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol
 
 from face_samples import FaceSampleCollector
 
-DEFAULT_TRACKING_HZ = 8.0
+DEFAULT_TRACKING_HZ = 2.0
 DEFAULT_MEDIA_BACKEND = "default"
 NO_MEDIA_BACKEND = "no_media"
 DEFAULT_CONNECT_RETRY_SECONDS = 3.0
@@ -110,7 +110,6 @@ class SdkReachyCompanion:
         self._on_face_sample_saved = on_face_sample_saved
         self._motion_lock = asyncio.Lock()
         self._face_task: asyncio.Task | None = None
-        self._face_sample_task: asyncio.Task | None = None
         self._speaking_task: asyncio.Task | None = None
         self._emotion_task: asyncio.Task | None = None
         self._closed = False
@@ -120,7 +119,6 @@ class SdkReachyCompanion:
         if self._closed:
             return
         self._awake = True
-        self._stop_face_sample_collection()
         async with self._motion_lock:
             await asyncio.to_thread(self._call_if_present, "enable_motors")
             await asyncio.to_thread(
@@ -151,7 +149,6 @@ class SdkReachyCompanion:
                     duration=1.0,
                     method="minjerk",
                 )
-        self._start_face_sample_collection()
 
     async def set_speaking(self, active: bool) -> None:
         if not self._config.speaking_motion_enabled or self._closed:
@@ -178,11 +175,8 @@ class SdkReachyCompanion:
         self._closed = True
         self._awake = False
         face_task = self._face_task
-        face_sample_task = self._face_sample_task
         self._cancel_task(face_task)
         self._face_task = None
-        self._cancel_task(face_sample_task)
-        self._face_sample_task = None
         self._cancel_task(self._speaking_task)
         self._cancel_task(self._emotion_task)
         await asyncio.gather(
@@ -192,7 +186,6 @@ class SdkReachyCompanion:
                     self._speaking_task,
                     self._emotion_task,
                     face_task,
-                    face_sample_task,
                 )
                 if task
             ),
@@ -221,21 +214,6 @@ class SdkReachyCompanion:
     def _stop_face_tracking(self) -> None:
         self._cancel_task(self._face_task)
         self._face_task = None
-
-    def _start_face_sample_collection(self) -> None:
-        if (
-            self._closed
-            or self._awake
-            or self._face_detector is None
-            or self._face_sample_collector is None
-        ):
-            return
-        if self._face_sample_task is None or self._face_sample_task.done():
-            self._face_sample_task = asyncio.create_task(self._face_sample_loop())
-
-    def _stop_face_sample_collection(self) -> None:
-        self._cancel_task(self._face_sample_task)
-        self._face_sample_task = None
 
     async def _speaking_loop(self) -> None:
         phase = 0
@@ -272,7 +250,7 @@ class SdkReachyCompanion:
         interval = 1.0 / max(self._config.tracking_hz, 1.0)
         smoothed: tuple[float, float] | None = None
         try:
-            while True:
+            while self._awake and not self._closed:
                 started = time.monotonic()
                 detection = await asyncio.to_thread(self._detect_face)
                 if detection is not None:
@@ -281,18 +259,6 @@ class SdkReachyCompanion:
                     await self._look_at_normalized_target(smoothed)
                 elapsed = time.monotonic() - started
                 await asyncio.sleep(max(0.0, interval - elapsed))
-        except asyncio.CancelledError:
-            pass
-
-    async def _face_sample_loop(self) -> None:
-        assert self._face_sample_collector is not None
-        interval = self._face_sample_collector.min_interval_seconds
-        try:
-            while True:
-                detection = await asyncio.to_thread(self._detect_face)
-                if detection is not None:
-                    self._notify_face_sample_saved(detection)
-                await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass
 

--- a/specs/face_tracking.md
+++ b/specs/face_tracking.md
@@ -131,8 +131,9 @@ on low-confidence matches.
 
 ## Testing
 
-Automated tests should not require the Reachy daemon, camera hardware, or model
-downloads. They should cover:
+Regular automated tests should not require the Reachy daemon, camera hardware,
+model downloads, model artifacts, or representative image datasets. They should
+cover pure logic:
 
 - parsing YuNet outputs into local detection objects
 - BGR/RGB conversion behavior for model input and saved crops
@@ -140,6 +141,13 @@ downloads. They should cover:
 - temporal promotion from candidate to active target
 - smoothing and jump rejection
 - sample metadata fields for boxes, landmarks, and aligned crops
+
+Model validation tests should be marked with the pytest `model` marker and run
+through `make test-model`, not through the regular `make test` suite. These tests
+may load local model artifacts and representative image fixtures to check
+detector quality, threshold behavior, landmark shape, and recognition embedding
+stability. They still should not require the Reachy daemon or live camera unless
+they are also marked as manual.
 
 Manual tests may use the real Reachy camera or simulator and should be explicit
 entry points outside `make test`.

--- a/specs/face_tracking.md
+++ b/specs/face_tracking.md
@@ -62,7 +62,7 @@ Default tuning should prefer reliable positives:
 - reject implausible aspect ratios or boxes clipped too tightly to frame edges
 - choose the best target by confidence and size, with bias toward the current
   tracked face to avoid unnecessary jumps
-- run at a bounded cadence, initially around 8 detections per second
+- run at a bounded cadence, initially around 2 detections per second
 - drop stale frames instead of building a backlog
 
 The exact thresholds are configuration values owned by `reachy/`, not Gemini
@@ -78,8 +78,9 @@ maintain a short-lived track state:
 - keep an active target through brief misses for a small grace window
 - smooth target coordinates before converting them to head motion
 - reject sudden large jumps unless the previous target has been lost
-- stop commanding face tracking while Reachy is sleeping, playing an emotion, or
-  otherwise under another motion mode
+- stop face detection and face tracking while Reachy is sleeping
+- stop commanding face tracking while Reachy is playing an emotion or otherwise
+  under another motion mode
 
 Motion conversion remains conservative:
 

--- a/specs/face_tracking.md
+++ b/specs/face_tracking.md
@@ -1,0 +1,145 @@
+# Face Tracking and Recognition
+
+## Purpose
+
+Face tracking turns Reachy Mini camera frames into stable face targets for robot
+attention. It should favor precision over recall: a missed face is better than
+tracking a bottle, cabinet edge, or other face-like kitchen object.
+
+This spec also defines the detection output needed for a later face recognition
+pipeline. Recognition is not required for the first implementation step, but the
+detector should produce landmarks and aligned crops so recognition can be added
+without replacing the tracking pipeline.
+
+## Component Boundary
+
+The `reachy/` component owns face tracking because it owns Reachy camera access
+and robot motion. The Reachy Mini daemon and SDK provide camera frames only; they
+do not provide face detections, landmarks, identities, or tracking decisions.
+
+The normal frame source is:
+
+- `ReachyMini(...).media.get_frame()`
+- return type: `numpy.ndarray | None`
+- frame layout: OpenCV BGR image, shape `(height, width, 3)`, dtype `uint8`
+- `None` means the camera is unavailable or no frame is ready
+
+Face tracking code must treat daemon frames as BGR. Any saved images or model
+inputs that require RGB must convert explicitly.
+
+## Detection Model
+
+Use OpenCV YuNet as the default face detector. It is a better fit than Haar
+cascades because it provides confidence scores and five facial landmarks while
+remaining lightweight enough for a dedicated Mac Mini.
+
+Detector output should include:
+
+- bounding box in source-frame pixels: `x`, `y`, `width`, `height`
+- confidence score
+- five landmarks in source-frame pixels:
+  - left eye
+  - right eye
+  - nose tip
+  - left mouth corner
+  - right mouth corner
+- normalized tracking target:
+  - `x`: `-1.0` left, `0.0` center, `1.0` right
+  - `y`: `-1.0` top, `0.0` center, `1.0` bottom
+- optional aligned face crop for sample collection or recognition
+
+The model file should be managed as a local artifact with a clear source URL and
+checksum documented near the loader. It should not be downloaded during normal
+runtime.
+
+## Detection Policy
+
+Default tuning should prefer reliable positives:
+
+- reject detections below a configurable confidence threshold, initially around
+  `0.75` to `0.85`
+- reject tiny faces below a configurable minimum pixel size
+- reject implausible aspect ratios or boxes clipped too tightly to frame edges
+- choose the best target by confidence and size, with bias toward the current
+  tracked face to avoid unnecessary jumps
+- run at a bounded cadence, initially around 8 detections per second
+- drop stale frames instead of building a backlog
+
+The exact thresholds are configuration values owned by `reachy/`, not Gemini
+tools or speech-agent state.
+
+## Temporal Tracking
+
+Single-frame detections are not enough to move the robot. The tracker should
+maintain a short-lived track state:
+
+- require a new face to appear in at least 2 of the last 3 detection cycles
+  before it becomes the active target
+- keep an active target through brief misses for a small grace window
+- smooth target coordinates before converting them to head motion
+- reject sudden large jumps unless the previous target has been lost
+- stop commanding face tracking while Reachy is sleeping, playing an emotion, or
+  otherwise under another motion mode
+
+Motion conversion remains conservative:
+
+- map normalized horizontal target to bounded yaw
+- map normalized vertical target to bounded pitch
+- continue using the shared Reachy motion owner so background loops do not fight
+  over motors
+
+## Recognition-Ready Face Samples
+
+Face sample collection should save data that is useful for recognition:
+
+- original frame size
+- detection box
+- confidence
+- landmarks
+- crop box
+- aligned crop path when available
+- source: `reachy`
+- capture timestamp
+- optional track id for grouping adjacent samples
+
+Saved crops should be aligned using the detector landmarks. Alignment should be
+deterministic so the same face pose produces comparable recognition inputs.
+
+Samples are unlabeled by default. A later labeling workflow can associate crops
+with known people from `core/people` or another public people API, but `reachy/`
+must not reach into unrelated component internals.
+
+## Future Recognition Pipeline
+
+The next recognition step should use embeddings rather than direct image
+comparison. The preferred simple stack is:
+
+1. YuNet detection and landmarks
+2. landmark-based alignment
+3. OpenCV SFace or another ArcFace-style embedding model
+4. nearest-neighbor matching against labeled household embeddings
+5. confidence and margin checks before accepting an identity
+
+Identity results should be separate from detection results:
+
+- detection answers "where is a reliable face?"
+- recognition answers "whose face is this, if known?"
+
+Robot tracking may use reliable detections without identity. Any user-facing
+identity behavior must include an explicit unknown state and should avoid acting
+on low-confidence matches.
+
+## Testing
+
+Automated tests should not require the Reachy daemon, camera hardware, or model
+downloads. They should cover:
+
+- parsing YuNet outputs into local detection objects
+- BGR/RGB conversion behavior for model input and saved crops
+- confidence, size, and aspect-ratio filtering
+- temporal promotion from candidate to active target
+- smoothing and jump rejection
+- sample metadata fields for boxes, landmarks, and aligned crops
+
+Manual tests may use the real Reachy camera or simulator and should be explicit
+entry points outside `make test`.

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -58,6 +58,7 @@ These should run as asyncio tasks under one application supervisor where practic
 - `specs/speech_agent.md`: wake-word and Gemini Live component.
 - `specs/kitchen_timer.md`: kitchen timer state, commands, events, and display snapshots.
 - `specs/reachy.md`: Reachy Mini companion component.
+- `specs/face_tracking.md`: Reachy camera face detection, tracking, and recognition-ready outputs.
 - `specs/core.md`: shared infrastructure and people data.
 - `specs/audio.md`: generated chore announcement audio.
 

--- a/specs/reachy.md
+++ b/specs/reachy.md
@@ -58,7 +58,7 @@ All motor commands pass through one motion owner inside `reachy/`. Sleep/wake tr
 
 ## Face Tracking
 
-Face tracking is a rate-limited background vision loop active in the `awake` state. The loop reads frames from the Reachy camera, detects nearby faces, chooses a target face, smooths the target over time, and sends a look target to the motion owner. It runs at a bounded cadence, initially around 8 detections per second, and drops stale frames rather than trying to process every camera frame.
+Face tracking is a rate-limited background vision loop active in the `awake` state. The loop reads frames from the Reachy camera, detects nearby faces, chooses a target face, smooths the target over time, and sends a look target to the motion owner. It runs at a bounded cadence, initially around 2 detections per second, and drops stale frames rather than trying to process every camera frame. Face detection must not run while Reachy is sleeping.
 
 The normal frame source is `mini.media.get_frame()` without Reachy audio. Direct OpenCV camera capture is the fallback when SDK media conflicts with host audio.
 

--- a/specs/reachy.md
+++ b/specs/reachy.md
@@ -62,6 +62,8 @@ Face tracking is a rate-limited background vision loop active in the `awake` sta
 
 The normal frame source is `mini.media.get_frame()` without Reachy audio. Direct OpenCV camera capture is the fallback when SDK media conflicts with host audio.
 
+Detailed detection, temporal tracking, face sample, and recognition-readiness requirements are in `specs/face_tracking.md`.
+
 ## Emotions
 
 The component exposes a curated local emotion enum:

--- a/tests/test_reachy_companion.py
+++ b/tests/test_reachy_companion.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from kitchen_agent import prepare_reachy_for_startup
 from reachy.companion import (
+    DEFAULT_TRACKING_HZ,
+    FaceDetection,
     NoOpReachyCompanion,
     ReachyConfig,
     ReachyEmotion,
@@ -35,6 +37,15 @@ class FakeMini:
         self.calls.append(("close",))
 
 
+class FakeFaceDetector:
+    def __init__(self) -> None:
+        self.frames = []
+
+    def detect(self, frame) -> FaceDetection | None:
+        self.frames.append(frame)
+        return None
+
+
 def fake_head_pose(**kwargs):
     return {"head_pose": kwargs}
 
@@ -49,6 +60,11 @@ def test_enabled_reachy_uses_retrying_companion():
     companion = run_reachy_companion(ReachyConfig(enabled=True))
 
     assert isinstance(companion, RetryingReachyCompanion)
+
+
+def test_default_face_tracking_rate_is_two_hz():
+    assert DEFAULT_TRACKING_HZ == 2.0
+    assert ReachyConfig().tracking_hz == 2.0
 
 
 def test_retrying_companion_reconnects_after_initial_failure():
@@ -176,6 +192,26 @@ def test_wake_and_sleep_use_reachy_motion_api():
     assert mini.calls[1][0] == "goto_target"
     assert ("goto_sleep",) in mini.calls
     assert ("close",) in mini.calls
+
+
+def test_sleep_does_not_start_face_detection():
+    mini = FakeMini()
+    detector = FakeFaceDetector()
+    companion = SdkReachyCompanion(
+        mini,
+        create_head_pose=fake_head_pose,
+        config=ReachyConfig(enabled=True, face_tracking_enabled=True),
+        face_detector=detector,
+    )
+
+    async def run() -> None:
+        await companion.sleep()
+        await asyncio.sleep(0)
+        await companion.close()
+
+    asyncio.run(run())
+
+    assert detector.frames == []
 
 
 def test_show_emotion_queues_curated_motion():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a dedicated face tracking and recognition spec
- Document Reachy daemon camera-frame inputs and BGR handling
- Specify YuNet-based detection, temporal filtering, recognition-ready samples, and future embedding flow
- Rate-limit current Reachy face detection to 2 Hz by default
- Ensure face detection only runs while Reachy is awake; remove the sleeping-state sample detection loop
- Add a pytest `model` marker and `make test-model` for explicit model validation outside the regular suite
- Keep regular `make test` focused on non-manual, non-model tests
- Link the new spec from the overview and Reachy component spec

## Testing
- `uv run python -m py_compile reachy/companion.py tests/test_reachy_companion.py`
- Full tests not run; runtime/hardware validation is not applicable in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed18f-30df-797a-ab52-7707d6f480a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed18f-30df-797a-ab52-7707d6f480a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

