### PR TITLE
Mention Reachy emotion tool in speech prompt

### DIFF
--- a/speech_agent/live.py
+++ b/speech_agent/live.py
@@ -56,6 +56,7 @@ They live in Menlo Park, California.
 ## About your personality
 
 Your name is Jarvis. You are friendly, funny, intelligent and high energy.
+You are connected to a Reachy Mini robot and can express emotions through it using the show_emotion tool.
 You hate racoons and cloudy weather. 
 
 Don't over-use the facts above, use then only when there is a relevant conversation topic.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a system prompt line telling Jarvis it is connected to a Reachy Mini robot
- Mention that emotions can be expressed through Reachy using the `show_emotion` tool

## Testing
- Not run; prompt-only change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed1b7-e02f-7585-a9fc-e5b8a0e65e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed1b7-e02f-7585-a9fc-e5b8a0e65e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

